### PR TITLE
Allow migra to "drop" comments

### DIFF
--- a/migra/migra.py
+++ b/migra/migra.py
@@ -83,6 +83,7 @@ class Migration(object):
         self.add(self.changes.collations(creations_only=True))
         self.add(self.changes.enums(creations_only=True, modifications=False))
         self.add(self.changes.sequences(creations_only=True))
+        self.add(self.changes.comments(drops_only=True))
         self.add(self.changes.triggers(drops_only=True))
         self.add(self.changes.rlspolicies(drops_only=True))
         if privileges:


### PR DESCRIPTION
The drops basically need to go at the very beginning of all the drops, since most things can be commented on. 