### PR TITLE
Using latest version of schemainspect, this will now properly put parens around policies using `with check`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ python = ">=3.6,<4"
 sqlbag = "*"
 six = "*"
 # schemainspect = {path="../schemainspect"}
-schemainspect = { git = "https://github.com/discatech/schemainspect.git", branch = "9163c1f340f7459f63ff52afd1ace26187e45c58", develop = true }
+schemainspect = { git = "https://github.com/discatech/schemainspect.git", branch = "83956861e1960c861da08a1d8d9dbc82be159ab0", develop = true }
 psycopg2-binary = { version="*", optional = true }
 
 [tool.poetry.dev-dependencies]

--- a/tests/FIXTURES/rls/a.sql
+++ b/tests/FIXTURES/rls/a.sql
@@ -1,8 +1,17 @@
 CREATE TABLE accounts (manager text, company text, contact_email text);
 
+CREATE FUNCTION is_manager(manager text, out success boolean) returns boolean as $$
+begin
+    select manager = current_user into success;
+end;
+$$ language plpgsql stable;
+
 ALTER TABLE accounts ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY account_managers ON accounts TO schemainspect_test_role
+CREATE POLICY account_managers_update ON accounts FOR UPDATE TO schemainspect_test_role
     USING (manager = current_user);
+
+CREATE POLICY account_managers_insert ON accounts FOR INSERT TO schemainspect_test_role
+    WITH CHECK (is_manager(manager));
 
 CREATE TABLE accounts2 (manager text, company text, contact_email text);

--- a/tests/FIXTURES/rls/b.sql
+++ b/tests/FIXTURES/rls/b.sql
@@ -1,9 +1,18 @@
 CREATE TABLE accounts (manager text, company text, contact_email text);
 
+CREATE FUNCTION is_manager(manager text, out success boolean) returns boolean as $$
+begin
+    select manager = current_user into success;
+end;
+$$ language plpgsql stable;
+
 ALTER TABLE accounts ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY account_managers ON accounts as restrictive TO schemainspect_test_role
+CREATE POLICY account_managers_update ON accounts as restrictive FOR UPDATE TO schemainspect_test_role
     USING (manager = current_user);
+
+CREATE POLICY account_managers_insert ON accounts as restrictive FOR INSERT TO schemainspect_test_role
+    WITH CHECK (is_manager(manager));
 
 CREATE TABLE accounts2 (manager text, company text, contact_email text);
 

--- a/tests/FIXTURES/rls/expected.sql
+++ b/tests/FIXTURES/rls/expected.sql
@@ -1,10 +1,20 @@
-drop policy "account_managers" on "public"."accounts";
+drop policy "account_managers_insert" on "public"."accounts";
+
+drop policy "account_managers_update" on "public"."accounts";
 
 alter table "public"."accounts2" enable row level security;
 
-create policy "account_managers"
+create policy "account_managers_insert"
 on "public"."accounts"
 as restrictive
-for all
+for insert
+to schemainspect_test_role
+with check (is_manager(manager));
+
+
+create policy "account_managers_update"
+on "public"."accounts"
+as restrictive
+for update
 to schemainspect_test_role
 using ((manager = CURRENT_USER));

--- a/tests/FIXTURES/rls/expected.sql
+++ b/tests/FIXTURES/rls/expected.sql
@@ -1,10 +1,10 @@
 drop policy if exists "account_managers_insert" on "public"."accounts";
 
-drop policy "account_managers_update" on "public"."accounts";
+drop policy if exists "account_managers_update" on "public"."accounts";
 
 alter table "public"."accounts2" enable row level security;
 
-drop policy if exists "account_managers" on "public"."accounts";
+drop policy if exists "account_managers_insert" on "public"."accounts";
 create policy "account_managers_insert"
 on "public"."accounts"
 as restrictive
@@ -13,6 +13,7 @@ to schemainspect_test_role
 with check (is_manager(manager));
 
 
+drop policy if exists "account_managers_update" on "public"."accounts";
 create policy "account_managers_update"
 on "public"."accounts"
 as restrictive


### PR DESCRIPTION
- [ ] Run tests